### PR TITLE
Update elixir version to handle sobelow 0.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.11.2
+FROM elixir:1.18.3
 
 COPY sobelow.sh /sobelow.sh
 


### PR DESCRIPTION
Sobelow just relases 0.14.0 that requires elixir 1.12 to run.

<img width="1036" alt="image" src="https://github.com/user-attachments/assets/1da6ec9b-e940-4657-a60a-76af82a8af5d" />

This action failed for us because it always try to run on the latest sobelow.
I update the runtime env of this action to 1.18.3 so that it can go on for a while.