### PR TITLE
Update actions versions & other minor updates to docs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sobelow Action
 
-This is a GitHub Action for [Sobelow](https://github.com/nccgroup/sobelow), the security-focused static analyzer for the [Phoenix Framework](https://www.phoenixframework.org/).
+This is a GitHub Action for [Sobelow](https://github.com/sobelow/sobelow), the security-focused static analyzer for the [Phoenix Framework](https://www.phoenixframework.org/).
 
 The most basic workflow looks like this:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a GitHub Action for [Sobelow](https://github.com/sobelow/sobelow), the s
 
 The most basic workflow looks like this:
 
-```
+```yaml
 on: [push]
 
 jobs:
@@ -20,16 +20,16 @@ jobs:
           sarif_file: results.sarif
 ```
 
-This will scan your Phoenix application, and add findings to the Security tab of your repository. 
+This will scan your Phoenix application, and add findings to the Security tab of your repository.
 
 Two options are supported:
 
-* `report`: if set to "false", this will not generate a report, and will output findings to stdout. 
+* `report`: if set to "false", this will not generate a report, and will output findings to stdout.
 * `flags`: accepts arbitrary Sobelow flags.
 
 The following example uses `flags` to suppress `Config` findings:
 
-```
+```yaml
 on: [push]
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Sobelow Job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - id: run-action
         uses: sobelow/action@v1
-      - uses: github/codeql-action/upload-sarif@v1
+      - uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif
 ```
@@ -37,12 +37,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Sobelow Job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - id: run-action
         uses: sobelow/action@v1
         with:
           flags: '-i Config'
-      - uses: github/codeql-action/upload-sarif@v1
+      - uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif
 ```

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: "Output a results.sarif file for GitHub Security integration"
     default: true
   flags:
-    description: "Flags (https://github.com/nccgroup/sobelow#options)"
+    description: "Flags (https://github.com/sobelow/sobelow#options)"
 
 runs:
   using: 'docker'


### PR DESCRIPTION
Hey @houllette! 🖖 

This pull request performs some minor updates to the docs:
1. Fixes links to point to `sobelow/sobelow` instead of `nccgroup/sobelow`.
2. Adds `yaml` heading to code blocks to enable syntax highlighting.
3. Updates `actions/checkout` to `v5` (`v2` should still work but throw some deprecation warnings due to the nodejs version it uses being long deprecated).
4. Updates `codeql-action/upload-sarif` to `v4`.

💅 